### PR TITLE
Add Microchip megaAVR 0-series facilities skeleton

### DIFF
--- a/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/CMakeLists.txt
+++ b/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/CMakeLists.txt
@@ -15,3 +15,11 @@
 
 # Description: microlibrary static library Microchip megaAVR 0-series HIL, any target
 #       CMake rules.
+
+target_include_directories( microlibrary
+    PUBLIC include
+    )
+
+target_sources( microlibrary
+    PRIVATE source/microlibrary/microchip/megaavr0.cc
+    )

--- a/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/include/microlibrary/microchip/megaavr0.h
+++ b/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/include/microlibrary/microchip/megaavr0.h
@@ -1,0 +1,32 @@
+/**
+ * microlibrary
+ *
+ * Copyright 2024, Andrew Countryman <apcountryman@gmail.com> and the microlibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief microlibrary::Microchip::megaAVR0 interface.
+ */
+
+#ifndef MICROLIBRARY_MICROCHIP_MEGAAVR0_H
+#define MICROLIBRARY_MICROCHIP_MEGAAVR0_H
+
+/**
+ * \brief Microchip megaAVR 0-series facilities.
+ */
+namespace microlibrary::Microchip::megaAVR0 {
+} // namespace microlibrary::Microchip::megaAVR0
+
+#endif // MICROLIBRARY_MICROCHIP_MEGAAVR0_H

--- a/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/source/microlibrary/microchip/megaavr0.cc
+++ b/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/source/microlibrary/microchip/megaavr0.cc
@@ -1,0 +1,23 @@
+/**
+ * microlibrary
+ *
+ * Copyright 2024, Andrew Countryman <apcountryman@gmail.com> and the microlibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief microlibrary::Microchip::megaAVR0 implementation.
+ */
+
+#include "microlibrary/microchip/megaavr0.h"


### PR DESCRIPTION
Resolves #44 (Add Microchip megaAVR 0-series facilities skeleton).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring
- [ ] Performs a repository administrative action

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.
