### PR TITLE
Add generic Arm Cortex-M0+ HIL, hardware target configuration injection

### DIFF
--- a/docs/hils/ARM_CORTEX_M0PLUS/usage.md
+++ b/docs/hils/ARM_CORTEX_M0PLUS/usage.md
@@ -3,7 +3,15 @@
 ## Table of Contents
 
 1. [Configuration Options](#configuration-options)
+1. [Configuration Injection](#configuration-injection)
 
 ## Configuration Options
 
 The Arm Cortex-M0+ HIL supports the following configuration options:
+
+## Configuration Injection
+
+If `MICROLIBRARY_HIL` is `ARM_CORTEX_M0PLUS` and `MICROLIBRARY_TARGET` is `HARDWARE`, the
+following features can be configured for use with a specific Arm Cortex-M0+ implementation
+by creating a `microlibrary-arm-cortex-m0plus` library and following the instructions in
+the documentation for the feature:

--- a/libraries/microlibrary/ARM_CORTEX_M0PLUS/HARDWARE/CMakeLists.txt
+++ b/libraries/microlibrary/ARM_CORTEX_M0PLUS/HARDWARE/CMakeLists.txt
@@ -19,3 +19,16 @@
 if( NOT MICROLIBRARY_TARGET STREQUAL "HARDWARE" )
     return()
 endif( NOT MICROLIBRARY_TARGET STREQUAL "HARDWARE" )
+
+if( MICROLIBRARY_HIL STREQUAL "ARM_CORTEX_M0PLUS" )
+    if( TARGET microlibrary-arm-cortex-m0plus )
+        target_link_libraries( microlibrary
+            PUBLIC microlibrary-arm-cortex-m0plus
+            )
+    else( TARGET microlibrary-arm-cortex-m0plus )
+        message(
+            STATUS
+            "microlibrary-arm-cortex-m0plus target not found, using default configuration"
+            )
+    endif( TARGET microlibrary-arm-cortex-m0plus )
+endif( MICROLIBRARY_HIL STREQUAL "ARM_CORTEX_M0PLUS" )


### PR DESCRIPTION
Resolves #68 (Add generic Arm Cortex-M0+ HIL, hardware target configuration injection).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring
- [ ] Performs a repository administrative action

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.
