### PR TITLE
Add null-terminated ROM string output formatter

### DIFF
--- a/libraries/microlibrary/ANY/ANY/include/microlibrary/stream.h
+++ b/libraries/microlibrary/ANY/ANY/include/microlibrary/stream.h
@@ -1331,6 +1331,80 @@ class Output_Formatter<char const *> {
         -> Result<std::size_t>;
 };
 
+#if MICROLIBRARY_ROM_STRING_IS_HIL_DEFINED
+/**
+ * \brief Null-terminated ROM string output formatter.
+ */
+template<>
+class Output_Formatter<ROM::String> {
+  public:
+    /**
+     * \brief Constructor.
+     */
+    constexpr Output_Formatter() noexcept = default;
+
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] source The source of the move.
+     */
+    constexpr Output_Formatter( Output_Formatter && source ) noexcept = default;
+
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] original The original to copy.
+     */
+    constexpr Output_Formatter( Output_Formatter const & original ) noexcept = default;
+
+    /**
+     * \brief Destructor.
+     */
+    ~Output_Formatter() noexcept = default;
+
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    constexpr auto operator=( Output_Formatter && expression ) noexcept -> Output_Formatter & = default;
+
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    constexpr auto operator   =( Output_Formatter const & expression ) noexcept
+        -> Output_Formatter & = default;
+
+    /**
+     * \brief Write a formatted null-terminated ROM string to a stream.
+     *
+     * \param[in] stream The stream to write the formatted null-terminated ROM string to.
+     * \param[in] string The null-terminated ROM string to format.
+     *
+     * \return The number of characters written to the stream.
+     */
+    auto print( Output_Stream & stream, ROM::String string ) const noexcept -> std::size_t;
+
+    /**
+     * \brief Write a formatted null-terminated ROM string to a stream.
+     *
+     * \param[in] stream The stream to write the formatted null-terminated ROM string to.
+     * \param[in] string The null-terminated ROM string to format.
+     *
+     * \return The number of characters written to the stream if the write succeeded.
+     * \return An error code if the write failed.
+     */
+    auto print( Fault_Reporting_Output_Stream & stream, ROM::String string ) const noexcept
+        -> Result<std::size_t>;
+};
+#endif // MICROLIBRARY_ROM_STRING_IS_HIL_DEFINED
+
 } // namespace microlibrary
 
 #endif // MICROLIBRARY_STREAM_H

--- a/libraries/microlibrary/ANY/ANY/source/microlibrary/stream.cc
+++ b/libraries/microlibrary/ANY/ANY/source/microlibrary/stream.cc
@@ -287,4 +287,27 @@ auto Output_Formatter<char const *>::print( Fault_Reporting_Output_Stream & stre
     return std::strlen( string );
 }
 
+#if MICROLIBRARY_ROM_STRING_IS_HIL_DEFINED
+auto Output_Formatter<ROM::String>::print( Output_Stream & stream, ROM::String string ) const noexcept
+    -> std::size_t
+{
+    stream.put( string );
+
+    return ROM::length( string );
+}
+#endif // MICROLIBRARY_ROM_STRING_IS_HIL_DEFINED
+
+#if MICROLIBRARY_ROM_STRING_IS_HIL_DEFINED
+auto Output_Formatter<ROM::String>::print( Fault_Reporting_Output_Stream & stream, ROM::String string ) const noexcept
+    -> Result<std::size_t>
+{
+    auto result = stream.put( string );
+    if ( result.is_error() ) {
+        return result.error();
+    } // if
+
+    return ROM::length( string );
+}
+#endif // MICROLIBRARY_ROM_STRING_IS_HIL_DEFINED
+
 } // namespace microlibrary


### PR DESCRIPTION
Resolves #230 (Add null-terminated ROM string output formatter).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring
- [ ] Performs a repository administrative action

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.
