### PR TITLE
Add hex dump output format specifier

### DIFF
--- a/docs/io.md
+++ b/docs/io.md
@@ -271,6 +271,8 @@ header/source file pair:
 - `::microlibrary::Output_Formatter<::microlibrary::Format::Dec<Integer>>`
 - `::microlibrary::Format::Hex`
 - `::microlibrary::Output_Formatter<::microlibrary::Format::Hex<Integer>>`
+- `::microlibrary::Format::Hex_Dump`
+- `::microlibrary::Output_Formatter<::microlibrary::Format::Hex_Dump<Address, Iterator>>`
 
 The `::microlibrary::Format::Bin` class is used to print an integer type in binary.
 The `::microlibrary::Output_Formatter<::microlibrary::Format::Bin<Integer>>`
@@ -335,5 +337,31 @@ void foo( ::microlibrary::Output_Stream & stream ) noexcept
 {
     // output will be "0x0A"
     stream.print( ::microlibrary::Format::Hex{ std::uint8_t{ 0x0A } } );
+}
+```
+
+The `::microlibrary::Format::Hex_Dump` class is used to print a hex dump of data.
+The `::microlibrary::Output_Formatter<::microlibrary::Format::Hex_Dump<Address,
+Iterator>>` specialization does not support user formatting configuration.
+`::microlibrary::Output_Formatter<::microlibrary::Format::Hex_Dump<Address, Iterator>>`
+automated tests are defined in the `test-automated-microlibrary-format-hex_dump` automated
+test executable's
+[`main.cc`](https://github.com/apcountryman/microlibrary/blob/main/tests/automated/microlibrary/format/hex_dump/main.cc)
+source file.
+```c++
+#include <cstdint>
+#include <string_view>
+
+#include "microlibrary/format.h"
+#include "microlibrary/stream.h"
+
+void foo( ::microlibrary::Output_Stream & stream ) noexcept
+{
+    auto const data = std::string_view{ "{yZZk7V!/{>fm[lxV!$e|:" };
+
+    // output will be
+    // "0400  7B 79 5A 5A 6B 37 56 21 2F 7B 3E 66 6D 5B 6C 78  |{yZZk7V!/{>fm[lx|\n"
+    // "0410  56 21 24 65 7C 3A                                |V!$e|:|          \n"
+    stream.print( ::picolibrary::Format::Hex_Dump{ std::uint16_t{ 0x0400 }, data.begin(), data.end() } );
 }
 ```

--- a/libraries/microlibrary/ANY/ANY/include/microlibrary/format.h
+++ b/libraries/microlibrary/ANY/ANY/include/microlibrary/format.h
@@ -963,6 +963,8 @@ class Output_Formatter<Format::Hex_Dump<Address, Iterator>> {
     /**
      * \brief Format an integer (hex).
      *
+     * \tparam Integer The type of integer to format.
+     *
      * \param[in] integer The integer to format.
      * \param[out] location The location to write the formatted integer to.
      */
@@ -970,9 +972,9 @@ class Output_Formatter<Format::Hex_Dump<Address, Iterator>> {
     static void format_hex( Integer integer, typename Row::Iterator location ) noexcept
     {
         constexpr auto nibbles = std::uint_fast8_t{ std::numeric_limits<Integer>::digits / 4 };
-        auto           i       = typename Row::Reverse_Iterator{ location + nibbles };
-        for ( auto nibble = std::uint_fast8_t{ 0 }; nibble < nibbles;
-              ++nibble, ++i, integer >>= NIBBLE_DIGITS ) {
+        auto           nibble = std::uint_fast8_t{ 0 };
+        auto           i      = typename Row::Reverse_Iterator{ location + nibbles };
+        for ( ; nibble < nibbles; ++nibble, ++i, integer >>= NIBBLE_DIGITS ) {
             auto const n = static_cast<std::uint_fast8_t>( integer & NIBBLE_MASK );
 
             *i = n < 0xA ? '0' + n : 'A' + ( n - 0xA );

--- a/libraries/microlibrary/ANY/ANY/include/microlibrary/format.h
+++ b/libraries/microlibrary/ANY/ANY/include/microlibrary/format.h
@@ -23,12 +23,14 @@
 #ifndef MICROLIBRARY_FORMAT_H
 #define MICROLIBRARY_FORMAT_H
 
+#include <cctype>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <limits>
 #include <type_traits>
 
+#include "microlibrary/algorithm.h"
 #include "microlibrary/array.h"
 #include "microlibrary/integer.h"
 #include "microlibrary/result.h"
@@ -262,6 +264,117 @@ class Hex {
      * \brief The integer to be formatted.
      */
     Integer m_integer;
+};
+
+/**
+ * \brief Hex dump output format specifier.
+ *
+ * \tparam Address Data address. Must be an unsigned integer type.
+ * \tparam Iterator Data iterator. Data must be convertible to std::uint8_t.
+ */
+template<typename Address, typename Iterator>
+class Hex_Dump {
+  public:
+    static_assert( std::is_unsigned_v<Address> );
+
+    Hex_Dump() = delete;
+
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] address The address of the data to dump.
+     * \param[in] begin The beginning of the data to dump.
+     * \param[in] end The end of the data to dump.
+     */
+    constexpr Hex_Dump( Address address, Iterator begin, Iterator end ) noexcept :
+        m_address{ address },
+        m_begin{ begin },
+        m_end{ end }
+    {
+    }
+
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] source The source of the move.
+     */
+    constexpr Hex_Dump( Hex_Dump && source ) noexcept = default;
+
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] original The original to copy.
+     */
+    constexpr Hex_Dump( Hex_Dump const & original ) noexcept = default;
+
+    /**
+     * \brief Destructor.
+     */
+    ~Hex_Dump() noexcept = default;
+
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    constexpr auto operator=( Hex_Dump && expression ) noexcept -> Hex_Dump & = default;
+
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    constexpr auto operator=( Hex_Dump const & expression ) noexcept -> Hex_Dump & = default;
+
+    /**
+     * \brief Get the address of the data to dump.
+     *
+     * \return The address of the data to dump.
+     */
+    constexpr auto address() const noexcept -> Address
+    {
+        return m_address;
+    }
+
+    /**
+     * \brief Get the beginning of the data to dump.
+     *
+     * \return The beginning of the data to dump.
+     */
+    constexpr auto begin() const noexcept -> Iterator
+    {
+        return m_begin;
+    }
+
+    /**
+     * \brief Get the end of the data to dump.
+     *
+     * \return The end of the data to dump.
+     */
+    constexpr auto end() const noexcept -> Iterator
+    {
+        return m_end;
+    }
+
+  private:
+    /**
+     * \brief The address of the data to dump.
+     */
+    Address m_address;
+
+    /**
+     * \brief The beginning of the data to dump.
+     */
+    Iterator m_begin;
+
+    /**
+     * \brief The end of the data to dump.
+     */
+    Iterator m_end;
 };
 
 } // namespace microlibrary::Format
@@ -675,6 +788,238 @@ class Output_Formatter<Format::Hex<Integer>> {
         *i = '0';
 
         return formatted_integer;
+    }
+};
+
+/**
+ * \brief microlibrary::Format::Hex_Dump output formatter.
+ *
+ * \tparam Address Data address. Must be an unsigned integer type.
+ * \tparam Iterator Data iterator. Data must be convertible to std::uint8_t.
+ */
+template<typename Address, typename Iterator>
+class Output_Formatter<Format::Hex_Dump<Address, Iterator>> {
+  public:
+    /**
+     * \brief Constructor.
+     */
+    constexpr Output_Formatter() noexcept = default;
+
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] source The source of the move.
+     */
+    constexpr Output_Formatter( Output_Formatter && source ) noexcept = default;
+
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] original The original to copy.
+     */
+    constexpr Output_Formatter( Output_Formatter const & original ) noexcept = default;
+
+    /**
+     * \brief Destructor.
+     */
+    ~Output_Formatter() noexcept = default;
+
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    constexpr auto operator=( Output_Formatter && expression ) noexcept -> Output_Formatter & = default;
+
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    constexpr auto operator   =( Output_Formatter const & expression ) noexcept
+        -> Output_Formatter & = default;
+
+    /**
+     * \brief Write a formatted microlibrary::Format::Hex_Dump to a stream.
+     *
+     * \param[in] stream The stream to write the formatted microlibrary::Format::Hex_Dump
+     *            to.
+     * \param[in] hex_dump The microlibrary::Format::Hex_Dump to format.
+     *
+     * \return The number of characters written to the stream.
+     */
+    auto print( Output_Stream & stream, Format::Hex_Dump<Address, Iterator> const & hex_dump ) const noexcept
+        -> std::size_t
+    {
+        Row row;
+
+        auto address = hex_dump.address();
+        auto begin   = hex_dump.begin();
+        auto end     = hex_dump.end();
+        auto n       = std::size_t{ 0 };
+
+        for ( ; begin != end; address += ROW_BYTES, n += row.size() ) {
+            begin = generate_row( address, begin, end, row );
+
+            stream.put( row.begin(), row.end() );
+        } // for
+
+        return n;
+    }
+
+    /**
+     * \brief Write a formatted microlibrary::Format::Hex_Dump to a stream.
+     *
+     * \param[in] stream The stream to write the formatted microlibrary::Format::Hex_Dump
+     *            to.
+     * \param[in] hex_dump The microlibrary::Format::Hex_Dump to format.
+     *
+     * \return The number of characters written to the stream if the write succeeded.
+     * \return An error code if the write failed.
+     */
+    auto print( Fault_Reporting_Output_Stream & stream, Format::Hex_Dump<Address, Iterator> const & hex_dump ) const noexcept
+        -> Result<std::size_t>
+    {
+        Row row;
+
+        auto address = hex_dump.address();
+        auto begin   = hex_dump.begin();
+        auto end     = hex_dump.end();
+        auto n       = std::size_t{ 0 };
+
+        for ( ; begin != end; address += ROW_BYTES, n += row.size() ) {
+            begin = generate_row( address, begin, end, row );
+
+            auto result = stream.put( row.begin(), row.end() );
+            if ( result.is_error() ) {
+                return result.error();
+            } // if
+        }     // for
+
+        return n;
+    }
+
+  private:
+    /**
+     * \brief The number of bits in a nibble.
+     */
+    static constexpr auto NIBBLE_DIGITS = 4;
+
+    /**
+     * \brief Nibble bit mask.
+     */
+    static constexpr auto NIBBLE_MASK = mask<std::uint_fast8_t>( NIBBLE_DIGITS, 0 );
+
+    /**
+     * \brief The number of nibbles in an address.
+     */
+    static constexpr auto ADDRESS_NIBBLES = std::uint_fast8_t{ std::numeric_limits<Address>::digits
+                                                               / NIBBLE_DIGITS };
+
+    /**
+     * \brief The number of nibbles in a byte.
+     */
+    static constexpr auto BYTE_NIBBLES = std::uint_fast8_t{ std::numeric_limits<std::uint8_t>::digits
+                                                            / NIBBLE_DIGITS };
+
+    /**
+     * \brief Group separation spaces.
+     */
+    static constexpr auto GROUP_SEPARATION = std::uint_fast8_t{ 2 };
+
+    /**
+     * \brief The number of bytes in a row.
+     */
+    static constexpr auto ROW_BYTES = std::uint_fast8_t{ 16 };
+
+    /**
+     * \brief Row buffer address (hex) offset.
+     */
+    static constexpr auto ADDRESS_HEX_OFFSET = std::uint_fast8_t{ 0 };
+
+    /**
+     * \brief Row buffer data (hex) offset.
+     */
+    static constexpr auto DATA_HEX_OFFSET = std::uint_fast8_t{ ADDRESS_HEX_OFFSET + ADDRESS_NIBBLES
+                                                               + GROUP_SEPARATION };
+
+    /**
+     * \brief Row buffer data (ASCII) offset.
+     */
+    static constexpr auto DATA_ASCII_OFFSET = std::uint_fast8_t{
+        DATA_HEX_OFFSET + ( ( ( BYTE_NIBBLES + 1 ) * ROW_BYTES ) - 1 ) + GROUP_SEPARATION + 1
+    };
+
+    /**
+     * \brief Row buffer.
+     */
+    using Row =
+        Array<char, ADDRESS_NIBBLES + GROUP_SEPARATION + ( ( ( BYTE_NIBBLES + 1 ) * ROW_BYTES ) - 1 ) + GROUP_SEPARATION + 1 + ROW_BYTES + 1 + 1>;
+
+    /**
+     * \brief Format an integer (hex).
+     *
+     * \param[in] integer The integer to format.
+     * \param[out] location The location to write the formatted integer to.
+     */
+    template<typename Integer>
+    static void format_hex( Integer integer, typename Row::Iterator location ) noexcept
+    {
+        constexpr auto nibbles = std::uint_fast8_t{ std::numeric_limits<Integer>::digits / 4 };
+        auto           i       = typename Row::Reverse_Iterator{ location + nibbles };
+        for ( auto nibble = std::uint_fast8_t{ 0 }; nibble < nibbles;
+              ++nibble, ++i, integer >>= NIBBLE_DIGITS ) {
+            auto const n = static_cast<std::uint_fast8_t>( integer & NIBBLE_MASK );
+
+            *i = n < 0xA ? '0' + n : 'A' + ( n - 0xA );
+        } // for
+    }
+
+    /**
+     * \brief Format a byte (ASCII).
+     *
+     * \param[in] byte The byte to format.
+     * \param[out] location The location to write the formatted byte to.
+     */
+    static void format_ascii( std::uint8_t byte, typename Row::Iterator location ) noexcept
+    {
+        *location = std::isprint( byte ) ? static_cast<char>( byte ) : '.';
+    }
+
+    /**
+     * \brief Generate a row.
+     *
+     * \param[in] address The row's address.
+     * \param[in] begin The beginning of the data to dump.
+     * \param[in] end The end of the data to dump.
+     * \param[out] row The row buffer to write the generated row to.
+     *
+     * \return The beginning of the remaining data to dump.
+     */
+    static auto generate_row( Address address, Iterator begin, Iterator end, Row & row ) noexcept -> Iterator
+    {
+        fill( row.begin() + ADDRESS_NIBBLES, row.end() - 1, ' ' );
+
+        row.back() = '\n';
+
+        *( row.begin() + DATA_ASCII_OFFSET - 1 ) = '|';
+
+        format_hex( address, row.begin() + ADDRESS_HEX_OFFSET );
+
+        auto byte = std::uint_fast8_t{ 0 };
+        for ( ; begin != end and byte < ROW_BYTES; ++begin, ++byte ) {
+            format_hex(
+                static_cast<std::uint8_t>( *begin ),
+                row.begin() + DATA_HEX_OFFSET + ( ( BYTE_NIBBLES + 1 ) * byte ) );
+            format_ascii( static_cast<std::uint8_t>( *begin ), row.begin() + DATA_ASCII_OFFSET + byte );
+        } // for
+        *( row.begin() + DATA_ASCII_OFFSET + byte ) = '|';
+
+        return begin;
     }
 };
 

--- a/tests/automated/microlibrary/format/hex_dump/CMakeLists.txt
+++ b/tests/automated/microlibrary/format/hex_dump/CMakeLists.txt
@@ -13,16 +13,22 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# Description: microlibrary::Format automated tests CMake rules.
+# Description: microlibrary::Format::Hex_Dump automated tests CMake rules.
 
-# microlibrary::Format::Bin automated tests
-add_subdirectory( bin )
+add_executable( test-automated-microlibrary-format-hex_dump )
 
-# microlibrary::Format::Dec automated tests
-add_subdirectory( dec )
+target_sources( test-automated-microlibrary-format-hex_dump
+    PRIVATE main.cc
+    )
 
-# microlibrary::Format::Hex automated tests
-add_subdirectory( hex )
+target_link_libraries( test-automated-microlibrary-format-hex_dump
+    PRIVATE gmock
+    PRIVATE gmock_main
+    PRIVATE gtest
+    PRIVATE microlibrary
+    )
 
-# microlibrary::Format::Hex_Dump automated tests
-add_subdirectory( hex_dump )
+add_test(
+    NAME    test-automated-microlibrary-format-hex_dump
+    COMMAND test-automated-microlibrary-format-hex_dump ${MICROLIBRARY_AUTOMATED_TESTS_OPTIONS}
+    )

--- a/tests/automated/microlibrary/format/hex_dump/main.cc
+++ b/tests/automated/microlibrary/format/hex_dump/main.cc
@@ -1,0 +1,487 @@
+/**
+ * microlibrary
+ *
+ * Copyright 2024, Andrew Countryman <apcountryman@gmail.com> and the microlibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief microlibrary::Format::Hex_Dump automated tests.
+ */
+
+#include <cstdint>
+#include <iomanip>
+#include <ios>
+#include <limits>
+#include <ostream>
+#include <string>
+#include <string_view>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "microlibrary/format.h"
+#include "microlibrary/testing/automated/error.h"
+#include "microlibrary/testing/automated/stream.h"
+
+namespace {
+
+using ::microlibrary::Format::Hex_Dump;
+using ::microlibrary::Testing::Automated::Fault_Reporting_Output_String_Stream;
+using ::microlibrary::Testing::Automated::Mock_Error;
+using ::microlibrary::Testing::Automated::Mock_Fault_Reporting_Output_Stream;
+using ::microlibrary::Testing::Automated::Output_String_Stream;
+using ::testing::A;
+using ::testing::Return;
+using ::testing::TestWithParam;
+using ::testing::ValuesIn;
+
+} // namespace
+
+/**
+ * \brief Verify microlibrary::Output_Formatter<microlibrary::Format::Hex_Dump<Address,
+ *        Iterator>>::print( microlibrary::Fault_Reporting_Output_Stream &,
+ *        microlibrary::Format::Hex_Dump<Address, Iterator> const & ) properly handles a
+ *        put error.
+ */
+TEST( outputFormatterFormatHexDumpPrintFaultReportingOutputStreamErrorHandling, putError )
+{
+    auto stream = Mock_Fault_Reporting_Output_Stream{};
+
+    auto const error = Mock_Error{ 153 };
+
+    EXPECT_CALL( stream.driver(), put( A<std::string>() ) ).WillOnce( Return( error ) );
+
+    auto const data = std::string_view{ "odMJz0Qd28QFM2" };
+
+    auto const result = stream.print( Hex_Dump{ std::uint16_t{ 0x36B2 }, data.begin(), data.end() } );
+
+    EXPECT_TRUE( result.is_error() );
+    EXPECT_EQ( result.error(), error );
+
+    EXPECT_FALSE( stream.end_of_file_reached() );
+    EXPECT_FALSE( stream.io_error_reported() );
+    EXPECT_TRUE( stream.fatal_error_reported() );
+}
+
+/**
+ * \brief microlibrary::Output_Formatter<microlibrary::Format::Hex_Dump<Address,
+ *        Iterator>>::print() test case.
+ */
+template<typename Address>
+struct outputFormatterFormatHexDumpPrint_Test_Case {
+    /**
+     * \brief The address of the data to dump.
+     */
+    Address address;
+
+    /**
+     * \brief The data to dump.
+     */
+    std::string_view data;
+
+    /**
+     * \brief The hex dump.
+     */
+    std::string_view hex_dump;
+};
+
+template<typename Address>
+auto operator<<( std::ostream & stream, outputFormatterFormatHexDumpPrint_Test_Case<Address> const & test_case )
+    -> std::ostream &
+{
+    // clang-format off
+
+    return stream << "{ "
+                  << ".address = 0x" << std::hex << std::uppercase << std::setw( std::numeric_limits<Address>::digits / 4 ) << std::setfill( '0' ) << test_case.address
+                  << ", "
+                  << ".data = " << test_case.data
+                  << " }";
+
+    // clang-format on
+}
+
+/**
+ * \brief microlibrary::Output_Formatter<microlibrary::Format::Hex_Dump<Address,
+ *        Iterator>>::print() std::uint16_t address test cases.
+ */
+outputFormatterFormatHexDumpPrint_Test_Case<std::uint16_t> const outputFormatterFormatHexDumpPrint16_TEST_CASES[]{
+    // clang-format off
+
+    {
+        0x3E4D,
+        "",
+        "",
+    },
+    {
+        0x0000,
+        "(Y !d5vz\t^2",
+        "0000  28 59 20 21 64 35 76 7A 09 5E 32                 |(Y !d5vz.^2|     \n"
+    },
+    {
+        0xFFFF,
+        ":X;27N8u]hde[e&+",
+        "FFFF  3A 58 3B 32 37 4E 38 75 5D 68 64 65 5B 65 26 2B  |:X;27N8u]hde[e&+|\n"
+    },
+    {
+        0x0000,
+        "{yZZk7V!/{>fm[lxV!$e|:",
+        "0000  7B 79 5A 5A 6B 37 56 21 2F 7B 3E 66 6D 5B 6C 78  |{yZZk7V!/{>fm[lx|\n"
+        "0010  56 21 24 65 7C 3A                                |V!$e|:|          \n"
+    },
+    {
+        0xFFFF,
+        "/B>wiGoUZ|6cjO(_`T.8jV:RxSUssq!L",
+        "FFFF  2F 42 3E 77 69 47 6F 55 5A 7C 36 63 6A 4F 28 5F  |/B>wiGoUZ|6cjO(_|\n"
+        "000F  60 54 2E 38 6A 56 3A 52 78 53 55 73 73 71 21 4C  |`T.8jV:RxSUssq!L|\n"
+    },
+    {
+        0x2627,
+        "(Y !d5vz\t^2",
+        "2627  28 59 20 21 64 35 76 7A 09 5E 32                 |(Y !d5vz.^2|     \n"
+    },
+    {
+        0x577B,
+        ":X;27N8u]hde[e&+",
+        "577B  3A 58 3B 32 37 4E 38 75 5D 68 64 65 5B 65 26 2B  |:X;27N8u]hde[e&+|\n"
+    },
+    {
+        0x95A1,
+        "{yZZk7V!/{>fm[lxV!$e|:",
+        "95A1  7B 79 5A 5A 6B 37 56 21 2F 7B 3E 66 6D 5B 6C 78  |{yZZk7V!/{>fm[lx|\n"
+        "95B1  56 21 24 65 7C 3A                                |V!$e|:|          \n"
+    },
+    {
+        0xD512,
+        "/B>wiGoUZ|6cjO(_`T.8jV:RxSUssq!L",
+        "D512  2F 42 3E 77 69 47 6F 55 5A 7C 36 63 6A 4F 28 5F  |/B>wiGoUZ|6cjO(_|\n"
+        "D522  60 54 2E 38 6A 56 3A 52 78 53 55 73 73 71 21 4C  |`T.8jV:RxSUssq!L|\n"
+    },
+
+    // clang-format on
+};
+
+/**
+ * \brief microlibrary::Output_Formatter<microlibrary::Format::Hex_Dump<Address,
+ *        Iterator>>::print( microlibrary::Output_Stream &,
+ *        microlibrary::Format::Hex_Dump<Address, Iterator> const & ) std::uint16_t
+ *        address test fixture.
+ */
+class outputFormatterFormatHexDumpPrintOutputStream16 :
+    public TestWithParam<outputFormatterFormatHexDumpPrint_Test_Case<std::uint16_t>> {
+};
+
+/**
+ * \brief Verify microlibrary::Output_Formatter<microlibrary::Format::Hex_Dump<Address,
+ *        Iterator>>::print( microlibrary::Output_Stream &,
+ *        microlibrary::Format::Hex_Dump<Address, Iterator> const & ) works properly.
+ */
+TEST_P( outputFormatterFormatHexDumpPrintOutputStream16, worksProperly )
+{
+    auto const test_case = GetParam();
+
+    auto stream = Output_String_Stream{};
+
+    auto const n = stream.print(
+        Hex_Dump{ test_case.address, test_case.data.begin(), test_case.data.end() } );
+
+    EXPECT_EQ( n, stream.string().size() );
+
+    EXPECT_TRUE( stream.is_nominal() );
+    EXPECT_EQ( stream.string(), test_case.hex_dump );
+}
+
+INSTANTIATE_TEST_SUITE_P(, outputFormatterFormatHexDumpPrintOutputStream16, ValuesIn( outputFormatterFormatHexDumpPrint16_TEST_CASES ) );
+
+/**
+ * \brief microlibrary::Output_Formatter<microlibrary::Format::Hex_Dump<Address,
+ *        Iterator>>::print( microlibrary::Fault_Reporting_Output_Stream &,
+ *        microlibrary::Format::Hex_Dump<Address, Iterator> const & ) std::uint16_t
+ *        address test fixture.
+ */
+class outputFormatterFormatHexDumpPrintFaultReportingOutputStream16 :
+    public TestWithParam<outputFormatterFormatHexDumpPrint_Test_Case<std::uint16_t>> {
+};
+
+/**
+ * \brief Verify microlibrary::Output_Formatter<microlibrary::Format::Hex_Dump<Address,
+ *        Iterator>>::print( microlibrary::Fault_Reporting_Output_Stream &,
+ *        microlibrary::Format::Hex_Dump<Address, Iterator> const & ) works properly.
+ */
+TEST_P( outputFormatterFormatHexDumpPrintFaultReportingOutputStream16, worksProperly )
+{
+    auto const test_case = GetParam();
+
+    auto stream = Fault_Reporting_Output_String_Stream{};
+
+    auto const result = stream.print(
+        Hex_Dump{ test_case.address, test_case.data.begin(), test_case.data.end() } );
+
+    EXPECT_FALSE( result.is_error() );
+    EXPECT_EQ( result.value(), stream.string().size() );
+
+    EXPECT_TRUE( stream.is_nominal() );
+    EXPECT_EQ( stream.string(), test_case.hex_dump );
+}
+
+INSTANTIATE_TEST_SUITE_P(, outputFormatterFormatHexDumpPrintFaultReportingOutputStream16, ValuesIn( outputFormatterFormatHexDumpPrint16_TEST_CASES ) );
+
+/**
+ * \brief microlibrary::Output_Formatter<microlibrary::Format::Hex_Dump<Address,
+ *        Iterator>>::print() std::uint32_t address test cases.
+ */
+outputFormatterFormatHexDumpPrint_Test_Case<std::uint32_t> const outputFormatterFormatHexDumpPrint32_TEST_CASES[]{
+    // clang-format off
+
+    {
+        0x5DED7EB6,
+        "",
+        "",
+    },
+    {
+        0x00000000,
+        "(Y !d5vz\t^2",
+        "00000000  28 59 20 21 64 35 76 7A 09 5E 32                 |(Y !d5vz.^2|     \n"
+    },
+    {
+        0xFFFFFFFF,
+        ":X;27N8u]hde[e&+",
+        "FFFFFFFF  3A 58 3B 32 37 4E 38 75 5D 68 64 65 5B 65 26 2B  |:X;27N8u]hde[e&+|\n"
+    },
+    {
+        0x00000000,
+        "{yZZk7V!/{>fm[lxV!$e|:",
+        "00000000  7B 79 5A 5A 6B 37 56 21 2F 7B 3E 66 6D 5B 6C 78  |{yZZk7V!/{>fm[lx|\n"
+        "00000010  56 21 24 65 7C 3A                                |V!$e|:|          \n"
+    },
+    {
+        0xFFFFFFFF,
+        "/B>wiGoUZ|6cjO(_`T.8jV:RxSUssq!L",
+        "FFFFFFFF  2F 42 3E 77 69 47 6F 55 5A 7C 36 63 6A 4F 28 5F  |/B>wiGoUZ|6cjO(_|\n"
+        "0000000F  60 54 2E 38 6A 56 3A 52 78 53 55 73 73 71 21 4C  |`T.8jV:RxSUssq!L|\n"
+    },
+    {
+        0x984DBBA7,
+        "(Y !d5vz\t^2",
+        "984DBBA7  28 59 20 21 64 35 76 7A 09 5E 32                 |(Y !d5vz.^2|     \n"
+    },
+    {
+        0xDA2C2551,
+        ":X;27N8u]hde[e&+",
+        "DA2C2551  3A 58 3B 32 37 4E 38 75 5D 68 64 65 5B 65 26 2B  |:X;27N8u]hde[e&+|\n"
+    },
+    {
+        0x3F4B1FCF,
+        "{yZZk7V!/{>fm[lxV!$e|:",
+        "3F4B1FCF  7B 79 5A 5A 6B 37 56 21 2F 7B 3E 66 6D 5B 6C 78  |{yZZk7V!/{>fm[lx|\n"
+        "3F4B1FDF  56 21 24 65 7C 3A                                |V!$e|:|          \n"
+    },
+    {
+        0x3F331547,
+        "/B>wiGoUZ|6cjO(_`T.8jV:RxSUssq!L",
+        "3F331547  2F 42 3E 77 69 47 6F 55 5A 7C 36 63 6A 4F 28 5F  |/B>wiGoUZ|6cjO(_|\n"
+        "3F331557  60 54 2E 38 6A 56 3A 52 78 53 55 73 73 71 21 4C  |`T.8jV:RxSUssq!L|\n"
+    },
+
+    // clang-format on
+};
+
+/**
+ * \brief microlibrary::Output_Formatter<microlibrary::Format::Hex_Dump<Address,
+ *        Iterator>>::print( microlibrary::Output_Stream &,
+ *        microlibrary::Format::Hex_Dump<Address, Iterator> const & ) std::uint32_t
+ *        address test fixture.
+ */
+class outputFormatterFormatHexDumpPrintOutputStream32 :
+    public TestWithParam<outputFormatterFormatHexDumpPrint_Test_Case<std::uint32_t>> {
+};
+
+/**
+ * \brief Verify microlibrary::Output_Formatter<microlibrary::Format::Hex_Dump<Address,
+ *        Iterator>>::print( microlibrary::Output_Stream &,
+ *        microlibrary::Format::Hex_Dump<Address, Iterator> const & ) works properly.
+ */
+TEST_P( outputFormatterFormatHexDumpPrintOutputStream32, worksProperly )
+{
+    auto const test_case = GetParam();
+
+    auto stream = Output_String_Stream{};
+
+    auto const n = stream.print(
+        Hex_Dump{ test_case.address, test_case.data.begin(), test_case.data.end() } );
+
+    EXPECT_EQ( n, stream.string().size() );
+
+    EXPECT_TRUE( stream.is_nominal() );
+    EXPECT_EQ( stream.string(), test_case.hex_dump );
+}
+
+INSTANTIATE_TEST_SUITE_P(, outputFormatterFormatHexDumpPrintOutputStream32, ValuesIn( outputFormatterFormatHexDumpPrint32_TEST_CASES ) );
+
+/**
+ * \brief microlibrary::Output_Formatter<microlibrary::Format::Hex_Dump<Address,
+ *        Iterator>>::print( microlibrary::Fault_Reporting_Output_Stream &,
+ *        microlibrary::Format::Hex_Dump<Address, Iterator> const & ) std::uint32_t
+ *        address test fixture.
+ */
+class outputFormatterFormatHexDumpPrintFaultReportingOutputStream32 :
+    public TestWithParam<outputFormatterFormatHexDumpPrint_Test_Case<std::uint32_t>> {
+};
+
+/**
+ * \brief Verify microlibrary::Output_Formatter<microlibrary::Format::Hex_Dump<Address,
+ *        Iterator>>::print( microlibrary::Fault_Reporting_Output_Stream &,
+ *        microlibrary::Format::Hex_Dump<Address, Iterator> const & ) works properly.
+ */
+TEST_P( outputFormatterFormatHexDumpPrintFaultReportingOutputStream32, worksProperly )
+{
+    auto const test_case = GetParam();
+
+    auto stream = Fault_Reporting_Output_String_Stream{};
+
+    auto const result = stream.print(
+        Hex_Dump{ test_case.address, test_case.data.begin(), test_case.data.end() } );
+
+    EXPECT_FALSE( result.is_error() );
+    EXPECT_EQ( result.value(), stream.string().size() );
+
+    EXPECT_TRUE( stream.is_nominal() );
+    EXPECT_EQ( stream.string(), test_case.hex_dump );
+}
+
+INSTANTIATE_TEST_SUITE_P(, outputFormatterFormatHexDumpPrintFaultReportingOutputStream32, ValuesIn( outputFormatterFormatHexDumpPrint32_TEST_CASES ) );
+
+/**
+ * \brief microlibrary::Output_Formatter<microlibrary::Format::Hex_Dump<Address,
+ *        Iterator>>::print() std::uint64_t address test cases.
+ */
+outputFormatterFormatHexDumpPrint_Test_Case<std::uint64_t> const outputFormatterFormatHexDumpPrint64_TEST_CASES[]{
+    // clang-format off
+
+    {
+        0x4A2283195D3ADAB6,
+        "",
+        "",
+    },
+    {
+        0x0000000000000000,
+        "(Y !d5vz\t^2",
+        "0000000000000000  28 59 20 21 64 35 76 7A 09 5E 32                 |(Y !d5vz.^2|     \n"
+    },
+    {
+        0xFFFFFFFFFFFFFFFF,
+        ":X;27N8u]hde[e&+",
+        "FFFFFFFFFFFFFFFF  3A 58 3B 32 37 4E 38 75 5D 68 64 65 5B 65 26 2B  |:X;27N8u]hde[e&+|\n"
+    },
+    {
+        0x0000000000000000,
+        "{yZZk7V!/{>fm[lxV!$e|:",
+        "0000000000000000  7B 79 5A 5A 6B 37 56 21 2F 7B 3E 66 6D 5B 6C 78  |{yZZk7V!/{>fm[lx|\n"
+        "0000000000000010  56 21 24 65 7C 3A                                |V!$e|:|          \n"
+    },
+    {
+        0xFFFFFFFFFFFFFFFF,
+        "/B>wiGoUZ|6cjO(_`T.8jV:RxSUssq!L",
+        "FFFFFFFFFFFFFFFF  2F 42 3E 77 69 47 6F 55 5A 7C 36 63 6A 4F 28 5F  |/B>wiGoUZ|6cjO(_|\n"
+        "000000000000000F  60 54 2E 38 6A 56 3A 52 78 53 55 73 73 71 21 4C  |`T.8jV:RxSUssq!L|\n"
+    },
+    {
+        0xCB91B0F9ADD06CED,
+        "(Y !d5vz\t^2",
+        "CB91B0F9ADD06CED  28 59 20 21 64 35 76 7A 09 5E 32                 |(Y !d5vz.^2|     \n"
+    },
+    {
+        0x499907CB64B7CDF9,
+        ":X;27N8u]hde[e&+",
+        "499907CB64B7CDF9  3A 58 3B 32 37 4E 38 75 5D 68 64 65 5B 65 26 2B  |:X;27N8u]hde[e&+|\n"
+    },
+    {
+        0x235570C8A88DC896,
+        "{yZZk7V!/{>fm[lxV!$e|:",
+        "235570C8A88DC896  7B 79 5A 5A 6B 37 56 21 2F 7B 3E 66 6D 5B 6C 78  |{yZZk7V!/{>fm[lx|\n"
+        "235570C8A88DC8A6  56 21 24 65 7C 3A                                |V!$e|:|          \n"
+    },
+    {
+        0x37F53DF0D3FC15DF,
+        "/B>wiGoUZ|6cjO(_`T.8jV:RxSUssq!L",
+        "37F53DF0D3FC15DF  2F 42 3E 77 69 47 6F 55 5A 7C 36 63 6A 4F 28 5F  |/B>wiGoUZ|6cjO(_|\n"
+        "37F53DF0D3FC15EF  60 54 2E 38 6A 56 3A 52 78 53 55 73 73 71 21 4C  |`T.8jV:RxSUssq!L|\n"
+    },
+
+    // clang-format on
+};
+
+/**
+ * \brief microlibrary::Output_Formatter<microlibrary::Format::Hex_Dump<Address,
+ *        Iterator>>::print( microlibrary::Output_Stream &,
+ *        microlibrary::Format::Hex_Dump<Address, Iterator> const & ) std::uint64_t
+ *        address test fixture.
+ */
+class outputFormatterFormatHexDumpPrintOutputStream64 :
+    public TestWithParam<outputFormatterFormatHexDumpPrint_Test_Case<std::uint64_t>> {
+};
+
+/**
+ * \brief Verify microlibrary::Output_Formatter<microlibrary::Format::Hex_Dump<Address,
+ *        Iterator>>::print( microlibrary::Output_Stream &,
+ *        microlibrary::Format::Hex_Dump<Address, Iterator> const & ) works properly.
+ */
+TEST_P( outputFormatterFormatHexDumpPrintOutputStream64, worksProperly )
+{
+    auto const test_case = GetParam();
+
+    auto stream = Output_String_Stream{};
+
+    auto const n = stream.print(
+        Hex_Dump{ test_case.address, test_case.data.begin(), test_case.data.end() } );
+
+    EXPECT_EQ( n, stream.string().size() );
+
+    EXPECT_TRUE( stream.is_nominal() );
+    EXPECT_EQ( stream.string(), test_case.hex_dump );
+}
+
+INSTANTIATE_TEST_SUITE_P(, outputFormatterFormatHexDumpPrintOutputStream64, ValuesIn( outputFormatterFormatHexDumpPrint64_TEST_CASES ) );
+
+/**
+ * \brief microlibrary::Output_Formatter<microlibrary::Format::Hex_Dump<Address,
+ *        Iterator>>::print( microlibrary::Fault_Reporting_Output_Stream &,
+ *        microlibrary::Format::Hex_Dump<Address, Iterator> const & ) std::uint64_t
+ *        address test fixture.
+ */
+class outputFormatterFormatHexDumpPrintFaultReportingOutputStream64 :
+    public TestWithParam<outputFormatterFormatHexDumpPrint_Test_Case<std::uint64_t>> {
+};
+
+/**
+ * \brief Verify microlibrary::Output_Formatter<microlibrary::Format::Hex_Dump<Address,
+ *        Iterator>>::print( microlibrary::Fault_Reporting_Output_Stream &,
+ *        microlibrary::Format::Hex_Dump<Address, Iterator> const & ) works properly.
+ */
+TEST_P( outputFormatterFormatHexDumpPrintFaultReportingOutputStream64, worksProperly )
+{
+    auto const test_case = GetParam();
+
+    auto stream = Fault_Reporting_Output_String_Stream{};
+
+    auto const result = stream.print(
+        Hex_Dump{ test_case.address, test_case.data.begin(), test_case.data.end() } );
+
+    EXPECT_FALSE( result.is_error() );
+    EXPECT_EQ( result.value(), stream.string().size() );
+
+    EXPECT_TRUE( stream.is_nominal() );
+    EXPECT_EQ( stream.string(), test_case.hex_dump );
+}
+
+INSTANTIATE_TEST_SUITE_P(, outputFormatterFormatHexDumpPrintFaultReportingOutputStream64, ValuesIn( outputFormatterFormatHexDumpPrint64_TEST_CASES ) );


### PR DESCRIPTION
Resolves #244 (Add hex dump output format specifier).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring
- [ ] Performs a repository administrative action

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.
