### PR TITLE
Use type system to indicate that peripheral instance pointers are not null

### DIFF
--- a/libraries/microlibrary/ANY/ANY/include/microlibrary/peripheral.h
+++ b/libraries/microlibrary/ANY/ANY/include/microlibrary/peripheral.h
@@ -25,6 +25,9 @@
 
 #include <cstdint>
 
+#include "microlibrary/pointer.h"
+#include "microlibrary/precondition.h"
+
 /**
  * \brief Peripheral facilities.
  */
@@ -54,9 +57,9 @@ class Instance {
      *
      * \return A pointer to the peripheral instance.
      */
-    static auto pointer() noexcept -> Type *
+    static auto pointer() noexcept -> Not_Null<Type *>
     {
-        return reinterpret_cast<Type *>( ADDRESS );
+        return Not_Null{ BYPASS_PRECONDITION_EXPECTATION_CHECKS, reinterpret_cast<Type *>( ADDRESS ) };
     }
 
     Instance() = delete;


### PR DESCRIPTION
Resolves #276 (Use type system to indicate that peripheral instance pointers are not null).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring
- [ ] Performs a repository administrative action

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.
