### PR TITLE
Add Microchip megaAVR 0-series register facilities skeleton

### DIFF
--- a/docs/hils/MICROCHIP_MEGAAVR0/index.md
+++ b/docs/hils/MICROCHIP_MEGAAVR0/index.md
@@ -3,3 +3,4 @@
 ## Table of Contents
 
 1. [Usage](usage.md)
+1. [Register Facilities](register.md)

--- a/docs/hils/MICROCHIP_MEGAAVR0/register.md
+++ b/docs/hils/MICROCHIP_MEGAAVR0/register.md
@@ -1,0 +1,8 @@
+# Register Facilities
+
+Microchip megaAVR 0-series register facilities are defined in the `microlibrary` static
+library's
+[`microlibrary/microchip/megaavr0/register.h`](https://github.com/apcountryman/microlibrary/blob/main/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/include/microlibrary/microchip/megaavr0/register.h)/[`microlibrary/microchip/megaavr0/register.cc`](https://github.com/apcountryman/microlibrary/blob/main/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/source/microlibrary/microchip/megaavr0/register.cc)
+header/source file pair.
+
+## Table of Contents

--- a/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/CMakeLists.txt
+++ b/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/CMakeLists.txt
@@ -22,4 +22,5 @@ target_include_directories( microlibrary
 
 target_sources( microlibrary
     PRIVATE source/microlibrary/microchip/megaavr0.cc
+    PRIVATE source/microlibrary/microchip/megaavr0/register.cc
     )

--- a/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/include/microlibrary/microchip/megaavr0/register.h
+++ b/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/include/microlibrary/microchip/megaavr0/register.h
@@ -1,0 +1,29 @@
+/**
+ * microlibrary
+ *
+ * Copyright 2024, Andrew Countryman <apcountryman@gmail.com> and the microlibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief microlibrary Microchip megaAVR 0-series register facilities interface.
+ */
+
+#ifndef MICROLIBRARY_MICROCHIP_MEGAAVR0_REGISTER_H
+#define MICROLIBRARY_MICROCHIP_MEGAAVR0_REGISTER_H
+
+namespace microlibrary::Microchip::megaAVR0 {
+} // namespace microlibrary::Microchip::megaAVR0
+
+#endif // MICROLIBRARY_MICROCHIP_MEGAAVR0_REGISTER_H

--- a/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/source/microlibrary/microchip/megaavr0/register.cc
+++ b/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/source/microlibrary/microchip/megaavr0/register.cc
@@ -1,0 +1,23 @@
+/**
+ * microlibrary
+ *
+ * Copyright 2024, Andrew Countryman <apcountryman@gmail.com> and the microlibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief microlibrary Microchip megaAVR 0-series register facilities implementation.
+ */
+
+#include "microlibrary/microchip/megaavr0/register.h"


### PR DESCRIPTION
Resolves #278 (Add Microchip megaAVR 0-series register facilities skeleton).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring
- [ ] Performs a repository administrative action

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.
