### PR TITLE
Add Microchip megaAVR 0-series facilities automated testing skeleton

### DIFF
--- a/tests/automated/microlibrary/microchip/megaavr0/CMakeLists.txt
+++ b/tests/automated/microlibrary/microchip/megaavr0/CMakeLists.txt
@@ -13,7 +13,4 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# Description: microlibrary::Microchip automated tests CMake rules.
-
-# microlibrary::Microchip::megaAVR0 automated tests
-add_subdirectory( megaavr0 )
+# Description: microlibrary::Microchip::megaAVR0 automated tests CMake rules.


### PR DESCRIPTION
Resolves #284 (Add Microchip megaAVR 0-series facilities automated testing skeleton).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring
- [ ] Performs a repository administrative action

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.
