### PR TITLE
Add Microchip megaAVR 0-series peripherals skeleton

### DIFF
--- a/docs/hils/MICROCHIP_MEGAAVR0/index.md
+++ b/docs/hils/MICROCHIP_MEGAAVR0/index.md
@@ -4,3 +4,4 @@
 
 1. [Usage](usage.md)
 1. [Register Facilities](register.md)
+1. [Peripheral Facilities](peripheral.md)

--- a/docs/hils/MICROCHIP_MEGAAVR0/peripheral.md
+++ b/docs/hils/MICROCHIP_MEGAAVR0/peripheral.md
@@ -1,0 +1,7 @@
+# Peripheral Facilities
+
+## Table of Contents
+
+1. [Peripherals](#peripherals)
+
+## Peripherals

--- a/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/CMakeLists.txt
+++ b/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/CMakeLists.txt
@@ -22,5 +22,6 @@ target_include_directories( microlibrary
 
 target_sources( microlibrary
     PRIVATE source/microlibrary/microchip/megaavr0.cc
+    PRIVATE source/microlibrary/microchip/megaavr0/peripheral.cc
     PRIVATE source/microlibrary/microchip/megaavr0/register.cc
     )

--- a/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/include/microlibrary/microchip/megaavr0/peripheral.h
+++ b/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/include/microlibrary/microchip/megaavr0/peripheral.h
@@ -1,0 +1,32 @@
+/**
+ * microlibrary
+ *
+ * Copyright 2024, Andrew Countryman <apcountryman@gmail.com> and the microlibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief microlibrary::Microchip::megaAVR0::Peripheral interface.
+ */
+
+#ifndef MICROLIBRARY_MICROCHIP_MEGAAVR0_PERIPHERAL_H
+#define MICROLIBRARY_MICROCHIP_MEGAAVR0_PERIPHERAL_H
+
+/**
+ * \brief Microchip megaAVR 0-series peripheral facilities.
+ */
+namespace microlibrary::Microchip::megaAVR0::Peripheral {
+} // namespace microlibrary::Microchip::megaAVR0::Peripheral
+
+#endif // MICROLIBRARY_MICROCHIP_MEGAAVR0_PERIPHERAL_H

--- a/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/source/microlibrary/microchip/megaavr0/peripheral.cc
+++ b/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/source/microlibrary/microchip/megaavr0/peripheral.cc
@@ -1,0 +1,23 @@
+/**
+ * microlibrary
+ *
+ * Copyright 2024, Andrew Countryman <apcountryman@gmail.com> and the microlibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief microlibrary::Microchip::megaAVR0::Peripheral implementation.
+ */
+
+#include "microlibrary/microchip/megaavr0/peripheral.h"


### PR DESCRIPTION
Resolves #286 (Add Microchip megaAVR 0-series peripherals skeleton).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring
- [ ] Performs a repository administrative action

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.
