### PR TITLE
Add Microchip megaAVR 0-series peripheral instances skeleton

### DIFF
--- a/docs/hils/MICROCHIP_MEGAAVR0/peripheral.md
+++ b/docs/hils/MICROCHIP_MEGAAVR0/peripheral.md
@@ -5,3 +5,16 @@
 1. [Peripherals](#peripherals)
 
 ## Peripherals
+
+Microchip megaAVR 0-series peripheral instances are defined in the `microlibrary` static
+library's
+[`microlibrary/microchip/megaavr0/peripheral/instances.h`](https://github.com/apcountryman/microlibrary/blob/main/libraries/microlibrary/MICROCHIP_MEGAAVR0/HARDWARE/include/microlibrary/microchip/megaavr0/peripheral/instances.h)/[`microlibrary/microchip/megaavr0/peripheral/instances.cc`](https://github.com/apcountryman/microlibrary/blob/main/libraries/microlibrary/MICROCHIP_MEGAAVR0/HARDWARE/source/microlibrary/microchip/megaavr0/peripheral/instances.cc)
+header/source file pair which is available if `MICROLIBRARY_TARGET` is `HARDWARE`.
+Peripheral instance names are based on the names used in the "Peripheral Module Address
+Map" table of the datasheets with the following change: a `0` is added to the end of the
+name of peripherals that only have a single instance to differentiate the peripheral name
+and the instance name.
+The following peripheral instances are defined (listed alphabetically):
+
+The availability of these peripheral instance definitions depends on the specific
+Microchip megaAVR 0-series microcontroller that is used.

--- a/docs/hils/MICROCHIP_MEGAAVR0/peripheral.md
+++ b/docs/hils/MICROCHIP_MEGAAVR0/peripheral.md
@@ -3,8 +3,11 @@
 ## Table of Contents
 
 1. [Peripherals](#peripherals)
+1. [Peripheral Instances](#peripheral-instances)
 
 ## Peripherals
+
+## Peripheral Instances
 
 Microchip megaAVR 0-series peripheral instances are defined in the `microlibrary` static
 library's

--- a/libraries/microlibrary/MICROCHIP_MEGAAVR0/HARDWARE/CMakeLists.txt
+++ b/libraries/microlibrary/MICROCHIP_MEGAAVR0/HARDWARE/CMakeLists.txt
@@ -20,6 +20,14 @@ if( NOT MICROLIBRARY_TARGET STREQUAL "HARDWARE" )
     return()
 endif( NOT MICROLIBRARY_TARGET STREQUAL "HARDWARE" )
 
+target_include_directories( microlibrary
+    PUBLIC include
+    )
+
+target_sources( microlibrary
+    PRIVATE source/microlibrary/microchip/megaavr0/peripheral/instances.cc
+    )
+
 target_link_libraries( microlibrary
     PUBLIC avr-libcpp
     )

--- a/libraries/microlibrary/MICROCHIP_MEGAAVR0/HARDWARE/include/microlibrary/microchip/megaavr0/peripheral/instances.h
+++ b/libraries/microlibrary/MICROCHIP_MEGAAVR0/HARDWARE/include/microlibrary/microchip/megaavr0/peripheral/instances.h
@@ -1,0 +1,29 @@
+/**
+ * microlibrary
+ *
+ * Copyright 2024, Andrew Countryman <apcountryman@gmail.com> and the microlibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief microlibrary Microchip megaAVR 0-series peripheral instances interface.
+ */
+
+#ifndef MICROLIBRARY_MICROCHIP_MEGAAVR0_PERIPHERAL_INSTANCES_H
+#define MICROLIBRARY_MICROCHIP_MEGAAVR0_PERIPHERAL_INSTANCES_H
+
+namespace microlibrary::Microchip::megaAVR0::Peripheral {
+} // namespace microlibrary::Microchip::megaAVR0::Peripheral
+
+#endif // MICROLIBRARY_MICROCHIP_MEGAAVR0_PERIPHERAL_INSTANCES_H

--- a/libraries/microlibrary/MICROCHIP_MEGAAVR0/HARDWARE/source/microlibrary/microchip/megaavr0/peripheral/instances.cc
+++ b/libraries/microlibrary/MICROCHIP_MEGAAVR0/HARDWARE/source/microlibrary/microchip/megaavr0/peripheral/instances.cc
@@ -1,0 +1,23 @@
+/**
+ * microlibrary
+ *
+ * Copyright 2024, Andrew Countryman <apcountryman@gmail.com> and the microlibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief microlibrary Microchip megaAVR 0-series peripheral instances implementation.
+ */
+
+#include "microlibrary/microchip/megaavr0/peripheral/instances.h"


### PR DESCRIPTION
Resolves #287 (Add Microchip megaAVR 0-series peripheral instances skeleton).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring
- [ ] Performs a repository administrative action

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.
