### PR TITLE
Allow construction/destruction of reserved registers when target is development environment to support automated testing

### DIFF
--- a/libraries/microlibrary/ANY/ANY/include/microlibrary/register.h
+++ b/libraries/microlibrary/ANY/ANY/include/microlibrary/register.h
@@ -156,13 +156,27 @@ class MICROLIBRARY_PACKED_REGISTER Reserved_Register {
      */
     using Type = T;
 
-    Reserved_Register() = delete;
+#if MICROLIBRARY_TARGET_IS_DEVELOPMENT_ENVIRONMENT
+    /**
+     * \brief Constructor.
+     */
+    Reserved_Register() noexcept = default;
+#else  // MICROLIBRARY_TARGET_IS_DEVELOPMENT_ENVIRONMENT
+    Reserved_Register()  = delete;
+#endif // MICROLIBRARY_TARGET_IS_DEVELOPMENT_ENVIRONMENT
 
     Reserved_Register( Reserved_Register && ) = delete;
 
     Reserved_Register( Reserved_Register const & ) = delete;
 
+#if MICROLIBRARY_TARGET_IS_DEVELOPMENT_ENVIRONMENT
+    /**
+     * \brief Destructor.
+     */
+    ~Reserved_Register() noexcept = default;
+#else  // MICROLIBRARY_TARGET_IS_DEVELOPMENT_ENVIRONMENT
     ~Reserved_Register() = delete;
+#endif // MICROLIBRARY_TARGET_IS_DEVELOPMENT_ENVIRONMENT
 
     auto operator=( Reserved_Register && ) = delete;
 


### PR DESCRIPTION
Resolves #297 (Allow construction/destruction of reserved registers when target is development environment to support automated testing).

Resolves #.

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring
- [ ] Performs a repository administrative action

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.
