### PR TITLE
Add Microchip megaAVR 0-series RSTCTRL peripheral

### DIFF
--- a/docs/hils/MICROCHIP_MEGAAVR0/peripheral.md
+++ b/docs/hils/MICROCHIP_MEGAAVR0/peripheral.md
@@ -4,6 +4,7 @@
 
 1. [Peripherals](#peripherals)
     1. [CLKCTRL](#clkctrl)
+    1. [RSTCTRL](#rstctrl)
 1. [Peripheral Instances](#peripheral-instances)
 
 ## Peripherals
@@ -42,6 +43,16 @@ The `::microlibrary::Microchip::megaAVR0::Peripheral::CLKCTRL` structure is defi
 [`microlibrary/microchip/megaavr0/peripheral/clkctrl.h`](https://github.com/apcountryman/microlibrary/blob/main/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/include/microlibrary/microchip/megaavr0/peripheral/clkctrl.h)/[`microlibrary/microchip/megaavr0/peripheral/clkctrl.cc`](https://github.com/apcountryman/microlibrary/blob/main/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/source/microlibrary/microchip/megaavr0/peripheral/clkctrl.cc)
 header/source file pair.
 
+### RSTCTRL
+
+The `::microlibrary::Microchip::megaAVR0::Peripheral::RSTCTRL` structure defines the
+layout of the Microchip megaAVR 0-series RSTCTRL peripheral and information about its
+registers.
+The `::microlibrary::Microchip::megaAVR0::Peripheral::RSTCTRL` structure is defined in the
+`microlibrary` static library's
+[`microlibrary/microchip/megaavr0/peripheral/rstctrl.h`](https://github.com/apcountryman/microlibrary/blob/main/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/include/microlibrary/microchip/megaavr0/peripheral/rstctrl.h)/[`microlibrary/microchip/megaavr0/peripheral/rstctrl.cc`](https://github.com/apcountryman/microlibrary/blob/main/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/source/microlibrary/microchip/megaavr0/peripheral/rstctrl.cc)
+header/source file pair.
+
 ## Peripheral Instances
 
 Microchip megaAVR 0-series peripheral instances are defined in the `microlibrary` static
@@ -54,6 +65,7 @@ name of peripherals that only have a single instance to differentiate the periph
 and the instance name.
 The following peripheral instances are defined (listed alphabetically):
 - `::microlibrary::Microchip::megaAVR0::Peripheral::CLKCTRL0`
+- `::microlibrary::Microchip::megaAVR0::Peripheral::RSTCTRL0`
 
 The availability of these peripheral instance definitions depends on the specific
 Microchip megaAVR 0-series microcontroller that is used.

--- a/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/CMakeLists.txt
+++ b/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/CMakeLists.txt
@@ -25,5 +25,6 @@ target_sources( microlibrary
     PRIVATE source/microlibrary/microchip/megaavr0/clock_controller.cc
     PRIVATE source/microlibrary/microchip/megaavr0/peripheral.cc
     PRIVATE source/microlibrary/microchip/megaavr0/peripheral/clkctrl.cc
+    PRIVATE source/microlibrary/microchip/megaavr0/peripheral/rstctrl.cc
     PRIVATE source/microlibrary/microchip/megaavr0/register.cc
     )

--- a/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/include/microlibrary/microchip/megaavr0/peripheral/rstctrl.h
+++ b/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/include/microlibrary/microchip/megaavr0/peripheral/rstctrl.h
@@ -1,0 +1,135 @@
+/**
+ * microlibrary
+ *
+ * Copyright 2024, Andrew Countryman <apcountryman@gmail.com> and the microlibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief microlibrary::Microchip::megaAVR0::Peripheral::RSTCTRL interface.
+ */
+
+#ifndef MICROLIBRARY_MICROCHIP_MEGAAVR0_PERIPHERAL_RSTCTRL_H
+#define MICROLIBRARY_MICROCHIP_MEGAAVR0_PERIPHERAL_RSTCTRL_H
+
+#include <cstdint>
+
+#include "microlibrary/integer.h"
+#include "microlibrary/microchip/megaavr0/register.h"
+#include "microlibrary/register.h"
+
+namespace microlibrary::Microchip::megaAVR0::Peripheral {
+
+/**
+ * \brief Microchip megaAVR 0-series Reset Controller (RSTCTRL) peripheral.
+ */
+struct RSTCTRL {
+    /**
+     * \brief Reset Flag Register (RSTFR) register information.
+     *
+     * This register has the following fields:
+     * - Power-on Reset Flag (PORF)
+     * - Brown-out Reset Flag (BORF)
+     * - External Reset Flag (EXTRF)
+     * - Watchdog Reset Flag (WDRF)
+     * - Software Reset Flag (SWRF)
+     * - UPDI Reset Flag (UPDIRF)
+     */
+    struct RSTFR {
+        /**
+         * \brief Field sizes.
+         */
+        struct Size {
+            static constexpr auto PORF      = std::uint_fast8_t{ 1 }; ///< PORF.
+            static constexpr auto BORF      = std::uint_fast8_t{ 1 }; ///< BORF.
+            static constexpr auto EXTRF     = std::uint_fast8_t{ 1 }; ///< EXTRF.
+            static constexpr auto WDRF      = std::uint_fast8_t{ 1 }; ///< WDRF.
+            static constexpr auto SWRF      = std::uint_fast8_t{ 1 }; ///< SWRF.
+            static constexpr auto UPDIRF    = std::uint_fast8_t{ 1 }; ///< UPDIRF.
+            static constexpr auto RESERVED6 = std::uint_fast8_t{ 2 }; ///< RESERVED6.
+        };
+
+        /**
+         * \brief Field bit positions.
+         */
+        struct Bit {
+            static constexpr auto PORF = std::uint_fast8_t{ 0 }; ///< PORF.
+            static constexpr auto BORF = std::uint_fast8_t{ PORF + Size::PORF }; ///< BORF.
+            static constexpr auto EXTRF = std::uint_fast8_t{ BORF + Size::BORF }; ///< EXTRF.
+            static constexpr auto WDRF = std::uint_fast8_t{ EXTRF + Size::EXTRF }; ///< WDRF.
+            static constexpr auto SWRF = std::uint_fast8_t{ WDRF + Size::WDRF }; ///< SWRF.
+            static constexpr auto UPDIRF = std::uint_fast8_t{ SWRF + Size::SWRF }; ///< UPDIRF.
+            static constexpr auto RESERVED6 = std::uint_fast8_t{ UPDIRF + Size::UPDIRF }; ///< RESERVED6.
+        };
+
+        /**
+         * \brief Field bit masks.
+         */
+        struct Mask {
+            static constexpr auto PORF = mask<std::uint8_t>( Size::PORF, Bit::PORF ); ///< PORF.
+            static constexpr auto BORF = mask<std::uint8_t>( Size::BORF, Bit::BORF ); ///< BORF.
+            static constexpr auto EXTRF = mask<std::uint8_t>( Size::EXTRF, Bit::EXTRF ); ///< EXTRF.
+            static constexpr auto WDRF = mask<std::uint8_t>( Size::WDRF, Bit::WDRF ); ///< WDRF.
+            static constexpr auto SWRF = mask<std::uint8_t>( Size::SWRF, Bit::SWRF ); ///< SWRF.
+            static constexpr auto UPDIRF = mask<std::uint8_t>( Size::UPDIRF, Bit::UPDIRF ); ///< UPDIRF.
+            static constexpr auto RESERVED6 = mask<std::uint8_t>( Size::RESERVED6, Bit::RESERVED6 ); ///< RESERVED6.
+        };
+    };
+
+    /**
+     * \brief Software Reset Register (SWRR) register information.
+     *
+     * This register has the following fields:
+     * - Software Reset Enable (SWRE)
+     */
+    struct SWRR {
+        /**
+         * \brief Field sizes.
+         */
+        struct Size {
+            static constexpr auto SWRE      = std::uint_fast8_t{ 1 }; ///< SWRE.
+            static constexpr auto RESERVED1 = std::uint_fast8_t{ 7 }; ///< RESERVED1.
+        };
+
+        /**
+         * \brief Field bit positions.
+         */
+        struct Bit {
+            static constexpr auto SWRE = std::uint_fast8_t{ 0 }; ///< SWRE.
+            static constexpr auto RESERVED1 = std::uint_fast8_t{ SWRE + Size::SWRE }; ///< RESERVED1.
+        };
+
+        /**
+         * \brief Field bit masks.
+         */
+        struct Mask {
+            static constexpr auto SWRE = mask<std::uint8_t>( Size::SWRE, Bit::SWRE ); ///< SWRE.
+            static constexpr auto RESERVED1 = mask<std::uint8_t>( Size::RESERVED1, Bit::RESERVED1 ); ///< RESERVED1.
+        };
+    };
+
+    /**
+     * \brief Reset Flag Register (RSTFR) register.
+     */
+    Register<std::uint8_t> rstfr;
+
+    /**
+     * \brief Software Reset Register (SWRR) register.
+     */
+    Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG> swrr;
+};
+
+} // namespace microlibrary::Microchip::megaAVR0::Peripheral
+
+#endif // MICROLIBRARY_MICROCHIP_MEGAAVR0_PERIPHERAL_RSTCTRL_H

--- a/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/source/microlibrary/microchip/megaavr0/peripheral/rstctrl.cc
+++ b/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/source/microlibrary/microchip/megaavr0/peripheral/rstctrl.cc
@@ -17,28 +17,15 @@
 
 /**
  * \file
- * \brief microlibrary Microchip megaAVR 0-series peripheral instances interface.
+ * \brief microlibrary::Microchip::megaAVR0::Peripheral::RSTCTRL implementation.
  */
 
-#ifndef MICROLIBRARY_MICROCHIP_MEGAAVR0_PERIPHERAL_INSTANCES_H
-#define MICROLIBRARY_MICROCHIP_MEGAAVR0_PERIPHERAL_INSTANCES_H
-
-#include "microlibrary/microchip/megaavr0/peripheral/clkctrl.h"
 #include "microlibrary/microchip/megaavr0/peripheral/rstctrl.h"
-#include "microlibrary/peripheral.h"
 
 namespace microlibrary::Microchip::megaAVR0::Peripheral {
 
-/**
- * \brief RSTCTRL0.
- */
-using RSTCTRL0 = ::microlibrary::Peripheral::Instance<RSTCTRL, 0x0040>;
-
-/**
- * \brief CLKCTRL0.
- */
-using CLKCTRL0 = ::microlibrary::Peripheral::Instance<CLKCTRL, 0x0060>;
+#if MICROLIBRARY_TARGET_IS_HARDWARE
+static_assert( sizeof( RSTCTRL ) == 0x01 + 1 );
+#endif // MICROLIBRARY_TARGET_IS_HARDWARE
 
 } // namespace microlibrary::Microchip::megaAVR0::Peripheral
-
-#endif // MICROLIBRARY_MICROCHIP_MEGAAVR0_PERIPHERAL_INSTANCES_H


### PR DESCRIPTION
Resolves #300 (Add Microchip megaAVR 0-series RSTCTRL peripheral).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring
- [ ] Performs a repository administrative action

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.
