### PR TITLE
Add Microchip megaAVR 0-series reset facilities skeleton

### DIFF
--- a/docs/hils/MICROCHIP_MEGAAVR0/index.md
+++ b/docs/hils/MICROCHIP_MEGAAVR0/index.md
@@ -6,3 +6,4 @@
 1. [Register Facilities](register.md)
 1. [Peripheral Facilities](peripheral.md)
 1. [Clock Facilities](clock.md)
+1. [Reset Facilities](reset.md)

--- a/docs/hils/MICROCHIP_MEGAAVR0/reset.md
+++ b/docs/hils/MICROCHIP_MEGAAVR0/reset.md
@@ -1,0 +1,8 @@
+# Reset Facilities
+
+Microchip megaAVR 0-series reset facilities are defined in the `microlibrary` static
+library's
+[`microlibrary/microchip/megaavr0/reset.h`](https://github.com/apcountryman/microlibrary/blob/main/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/include/microlibrary/microchip/megaavr0/reset.h)/[`microlibrary/microchip/megaavr0/reset.cc`](https://github.com/apcountryman/microlibrary/blob/main/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/source/microlibrary/microchip/megaavr0/reset.cc)
+header/source file pair.
+
+## Table of Contents

--- a/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/CMakeLists.txt
+++ b/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/CMakeLists.txt
@@ -27,4 +27,5 @@ target_sources( microlibrary
     PRIVATE source/microlibrary/microchip/megaavr0/peripheral/clkctrl.cc
     PRIVATE source/microlibrary/microchip/megaavr0/peripheral/rstctrl.cc
     PRIVATE source/microlibrary/microchip/megaavr0/register.cc
+    PRIVATE source/microlibrary/microchip/megaavr0/reset.cc
     )

--- a/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/include/microlibrary/microchip/megaavr0/reset.h
+++ b/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/include/microlibrary/microchip/megaavr0/reset.h
@@ -1,0 +1,29 @@
+/**
+ * microlibrary
+ *
+ * Copyright 2024, Andrew Countryman <apcountryman@gmail.com> and the microlibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief microlibrary Microchip megaAVR 0-series reset facilities interface.
+ */
+
+#ifndef MICROLIBRARY_MICROCHIP_MEGAAVR0_RESET_H
+#define MICROLIBRARY_MICROCHIP_MEGAAVR0_RESET_H
+
+namespace microlibrary::Microchip::megaAVR0 {
+} // namespace microlibrary::Microchip::megaAVR0
+
+#endif // MICROLIBRARY_MICROCHIP_MEGAAVR0_RESET_H

--- a/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/source/microlibrary/microchip/megaavr0/reset.cc
+++ b/libraries/microlibrary/MICROCHIP_MEGAAVR0/ANY/source/microlibrary/microchip/megaavr0/reset.cc
@@ -1,0 +1,23 @@
+/**
+ * microlibrary
+ *
+ * Copyright 2024, Andrew Countryman <apcountryman@gmail.com> and the microlibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief microlibrary Microchip megaAVR 0-series reset facilities implementation.
+ */
+
+#include "microlibrary/microchip/megaavr0/reset.h"

--- a/libraries/microlibrary/MICROCHIP_MEGAAVR0/DEVELOPMENT_ENVIRONMENT/CMakeLists.txt
+++ b/libraries/microlibrary/MICROCHIP_MEGAAVR0/DEVELOPMENT_ENVIRONMENT/CMakeLists.txt
@@ -27,4 +27,5 @@ target_include_directories( microlibrary
 target_sources( microlibrary
     PRIVATE source/microlibrary/testing/automated/microchip/megaavr0.cc
     PRIVATE source/microlibrary/testing/automated/microchip/megaavr0/clock.cc
+    PRIVATE source/microlibrary/testing/automated/microchip/megaavr0/reset.cc
     )

--- a/libraries/microlibrary/MICROCHIP_MEGAAVR0/DEVELOPMENT_ENVIRONMENT/include/microlibrary/testing/automated/microchip/megaavr0/reset.h
+++ b/libraries/microlibrary/MICROCHIP_MEGAAVR0/DEVELOPMENT_ENVIRONMENT/include/microlibrary/testing/automated/microchip/megaavr0/reset.h
@@ -1,0 +1,30 @@
+/**
+ * microlibrary
+ *
+ * Copyright 2024, Andrew Countryman <apcountryman@gmail.com> and the microlibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief microlibrary Microchip megaAVR 0-series reset automated testing facilities
+ *        interface.
+ */
+
+#ifndef MICROLIBRARY_TESTING_AUTOMATED_MICROCHIP_MEGAAVR0_RESET_H
+#define MICROLIBRARY_TESTING_AUTOMATED_MICROCHIP_MEGAAVR0_RESET_H
+
+namespace microlibrary::Testing::Automated::Microchip::megaAVR0 {
+} // namespace microlibrary::Testing::Automated::Microchip::megaAVR0
+
+#endif // MICROLIBRARY_TESTING_AUTOMATED_MICROCHIP_MEGAAVR0_RESET_H

--- a/libraries/microlibrary/MICROCHIP_MEGAAVR0/DEVELOPMENT_ENVIRONMENT/source/microlibrary/testing/automated/microchip/megaavr0/reset.cc
+++ b/libraries/microlibrary/MICROCHIP_MEGAAVR0/DEVELOPMENT_ENVIRONMENT/source/microlibrary/testing/automated/microchip/megaavr0/reset.cc
@@ -1,0 +1,24 @@
+/**
+ * microlibrary
+ *
+ * Copyright 2024, Andrew Countryman <apcountryman@gmail.com> and the microlibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief microlibrary Microchip megaAVR 0-series reset automated testing facilities
+ *        implementation.
+ */
+
+#include "microlibrary/testing/automated/microchip/megaavr0/reset.h"


### PR DESCRIPTION
Resolves #304 (Add Microchip megaAVR 0-series reset facilities skeleton).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring
- [ ] Performs a repository administrative action

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.
