### PR TITLE
Add Microchip megaAVR 0-series reset controller

### DIFF
--- a/docs/hils/MICROCHIP_MEGAAVR0/reset.md
+++ b/docs/hils/MICROCHIP_MEGAAVR0/reset.md
@@ -8,6 +8,7 @@ header/source file pair.
 ## Table of Contents
 
 1. [Reset Source](#reset-source)
+1. [Reset Controller](#reset-controller)
 
 ## Reset Source
 
@@ -32,3 +33,28 @@ The `::microlibrary::Microchip::megaAVR0::Reset_Source` class holds a Microchip 
   function.
 - To check if a UPDI reset has occurred, use the
   `::microlibrary::Microchip::megaAVR0::Reset_Source::is_updi_reset()` member function.
+
+## Reset Controller
+
+The `::microlibrary::Microchip::megaAVR0::Reset_Controller` reset controller class is used
+to interact with a Microchip megaAVR 0-series microcontroller's RSTCTRL peripheral.
+- To get the reset source(s), use the
+  `::microlibrary::Microchip::megaAVR0::Reset_Controller::reset_source()` member function.
+- To clear the reset source(s), use the
+  `::microlibrary::Microchip::megaAVR0::Reset_Controller::clear_reset_source()` member
+  function.
+- To initiate a software reset, use the
+  `::microlibrary::Microchip::megaAVR0::Reset_Controller::initiate_software_reset()`
+  member function.
+
+`::microlibrary::Microchip::megaAVR0::Reset_Controller` automated tests are defined in the
+`test-automated-microlibrary-microchip-megaavr0-reset_controller` automated test
+executable's
+[`main.cc`](https://github.com/apcountryman/microlibrary/blob/main/tests/automated/microlibrary/microchip/megaavr0/reset_controller/main.cc)
+source file.
+
+The `::microlibrary::Testing::Automated::Microchip::megaAVR0::Mock_Reset_Controller` mock
+reset controller class is available if `MICROLIBRARY_TARGET` is `DEVELOPMENT_ENVIRONMENT`.
+The mock is defined in the
+[`microlibrary/testing/automated/microchip/megaavr0/reset.h`](https://github.com/apcountryman/microlibrary/blob/main/libraries/microlibrary/MICROCHIP_MEGAAVR0/DEVELOPMENT_ENVIRONMENT/include/microlibrary/testing/automated/microchip/megaavr0/reset.h)/[`microlibrary/testing/automated/microchip/megaavr0/reset.cc`](https://github.com/apcountryman/microlibrary/blob/main/libraries/microlibrary/MICROCHIP_MEGAAVR0/DEVELOPMENT_ENVIRONMENT/source/microlibrary/testing/automated/microchip/megaavr0/reset.cc)
+header/source file pair.

--- a/libraries/microlibrary/MICROCHIP_MEGAAVR0/DEVELOPMENT_ENVIRONMENT/include/microlibrary/testing/automated/microchip/megaavr0/reset.h
+++ b/libraries/microlibrary/MICROCHIP_MEGAAVR0/DEVELOPMENT_ENVIRONMENT/include/microlibrary/testing/automated/microchip/megaavr0/reset.h
@@ -24,7 +24,39 @@
 #ifndef MICROLIBRARY_TESTING_AUTOMATED_MICROCHIP_MEGAAVR0_RESET_H
 #define MICROLIBRARY_TESTING_AUTOMATED_MICROCHIP_MEGAAVR0_RESET_H
 
+#include <cstdlib>
+
+#include "gmock/gmock.h"
+#include "microlibrary/microchip/megaavr0/reset.h"
+
 namespace microlibrary::Testing::Automated::Microchip::megaAVR0 {
+
+/**
+ * \brief Mock reset controller.
+ */
+class Mock_Reset_Controller {
+  public:
+    Mock_Reset_Controller() = default;
+
+    Mock_Reset_Controller( Mock_Reset_Controller && ) = delete;
+
+    Mock_Reset_Controller( Mock_Reset_Controller const & ) = delete;
+
+    ~Mock_Reset_Controller() noexcept = default;
+
+    auto operator=( Mock_Reset_Controller && ) = delete;
+
+    auto operator=( Mock_Reset_Controller const & ) = delete;
+
+    MOCK_METHOD( ::microlibrary::Microchip::megaAVR0::Reset_Source, reset_source, (), ( const ) );
+    MOCK_METHOD( void, clear_reset_source, () );
+
+    [[noreturn]] void initiate_software_reset()
+    {
+        std::exit( 0 );
+    }
+};
+
 } // namespace microlibrary::Testing::Automated::Microchip::megaAVR0
 
 #endif // MICROLIBRARY_TESTING_AUTOMATED_MICROCHIP_MEGAAVR0_RESET_H

--- a/tests/automated/microlibrary/microchip/megaavr0/CMakeLists.txt
+++ b/tests/automated/microlibrary/microchip/megaavr0/CMakeLists.txt
@@ -18,5 +18,8 @@
 # microlibrary::Microchip::megaAVR0::Clock_Controller automated tests
 add_subdirectory( clock_controller )
 
+# microlibrary::Microchip::megaAVR0::Reset_Controller automated tests
+add_subdirectory( reset_controller )
+
 # microlibrary::Microchip::megaAVR0::Reset_Source automated tests
 add_subdirectory( reset_source )

--- a/tests/automated/microlibrary/microchip/megaavr0/reset_controller/CMakeLists.txt
+++ b/tests/automated/microlibrary/microchip/megaavr0/reset_controller/CMakeLists.txt
@@ -1,0 +1,35 @@
+# microlibrary
+#
+# Copyright 2024, Andrew Countryman <apcountryman@gmail.com> and the microlibrary
+# contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# Description: microlibrary::Microchip::megaAVR0::Reset_Controller automated tests CMake
+#       rules.
+
+add_executable( test-automated-microlibrary-microchip-megaavr0-reset_controller )
+
+target_sources( test-automated-microlibrary-microchip-megaavr0-reset_controller
+    PRIVATE main.cc
+    )
+
+target_link_libraries( test-automated-microlibrary-microchip-megaavr0-reset_controller
+    PRIVATE gmock
+    PRIVATE gmock_main
+    PRIVATE gtest
+    PRIVATE microlibrary
+    )
+
+add_test(
+    NAME    test-automated-microlibrary-microchip-megaavr0-reset_controller
+    COMMAND test-automated-microlibrary-microchip-megaavr0-reset_controller ${MICROLIBRARY_AUTOMATED_TESTS_OPTIONS}
+    )

--- a/tests/automated/microlibrary/microchip/megaavr0/reset_controller/main.cc
+++ b/tests/automated/microlibrary/microchip/megaavr0/reset_controller/main.cc
@@ -1,0 +1,70 @@
+/**
+ * microlibrary
+ *
+ * Copyright 2024, Andrew Countryman <apcountryman@gmail.com> and the microlibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief microlibrary::Microchip::megaAVR0::Reset_Controller automated tests.
+ */
+
+#include <cstdint>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "microlibrary/microchip/megaavr0/peripheral/rstctrl.h"
+#include "microlibrary/microchip/megaavr0/reset.h"
+#include "microlibrary/pointer.h"
+
+namespace {
+
+using ::microlibrary::Not_Null;
+using ::microlibrary::Microchip::megaAVR0::Reset_Controller;
+using ::microlibrary::Microchip::megaAVR0::Peripheral::RSTCTRL;
+using ::testing::Return;
+
+} // namespace
+
+/**
+ * \brief Verify microlibrary::Microchip::megaAVR0::Clock_Controller::reset_source() works
+ *        properly.
+ */
+TEST( resetSource, worksProperly )
+{
+    auto const rstfr = std::uint8_t{ 0b01'0'1'0'0'1'1 };
+
+    auto rstctrl = RSTCTRL{};
+
+    auto const reset_controller = Reset_Controller{ Not_Null{ &rstctrl } };
+
+    EXPECT_CALL( rstctrl.rstfr, read() ).WillOnce( Return( rstfr ) );
+
+    EXPECT_EQ( reset_controller.reset_source().rstctrl_rstfr(), rstfr );
+}
+
+/**
+ * \brief Verify microlibrary::Microchip::megaAVR0::Clock_Controller::clear_reset_source()
+ *        works properly.
+ */
+TEST( clearResetSource, worksProperly )
+{
+    auto rstctrl = RSTCTRL{};
+
+    auto reset_controller = Reset_Controller{ Not_Null{ &rstctrl } };
+
+    EXPECT_CALL( rstctrl.rstfr, write( 0b00'1'1'1'1'1'1 ) );
+
+    reset_controller.clear_reset_source();
+}


### PR DESCRIPTION
Resolves #301 (Add Microchip megaAVR 0-series reset controller).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring
- [ ] Performs a repository administrative action

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.
