### PR TITLE
Fix missing Microchip megaAVR 0-series reset source documentation

### DIFF
--- a/docs/hils/MICROCHIP_MEGAAVR0/reset.md
+++ b/docs/hils/MICROCHIP_MEGAAVR0/reset.md
@@ -34,6 +34,11 @@ The `::microlibrary::Microchip::megaAVR0::Reset_Source` class holds a Microchip 
 - To check if a UPDI reset has occurred, use the
   `::microlibrary::Microchip::megaAVR0::Reset_Source::is_updi_reset()` member function.
 
+`::microlibrary::Microchip::megaAVR0::Reset_Source` automated tests are defined in the
+`test-automated-microlibrary-microchip-megaavr0-reset_source` automated test executable's
+[`main.cc`](https://github.com/apcountryman/microlibrary/blob/main/tests/automated/microlibrary/microchip/megaavr0/reset_source/main.cc)
+source file.
+
 ## Reset Controller
 
 The `::microlibrary::Microchip::megaAVR0::Reset_Controller` reset controller class is used


### PR DESCRIPTION
Resolves #309 (Fix missing Microchip megaAVR 0-series reset source documentation).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring
- [ ] Performs a repository administrative action

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.
